### PR TITLE
update environment variable DISPLAY

### DIFF
--- a/python_environment/docker-compose.yml
+++ b/python_environment/docker-compose.yml
@@ -8,7 +8,7 @@ services:
             dockerfile: Dockerfile
         environment: 
             PYTHONPATH: "/usr/local/lib/python3.8/site-packages:/work/src/ty_lib"
-            DISPLAY: docker.for.win.localhost:0.0
+            DISPLAY: host.docker.internal:0.0
         ports:
             - "8888"
         volumes:


### PR DESCRIPTION
please see the Release note. https://docs.docker.com/docker-for-windows/release-notes/
"Removed the deprecated DNS name docker.for.win.localhost. Use DNS name host.docker.internal in a container to access services that are running on the host. docker/for-win#10619"